### PR TITLE
fix registration page to only allow admin

### DIFF
--- a/src/components/RegisterPage/RegisterPage.js
+++ b/src/components/RegisterPage/RegisterPage.js
@@ -2,7 +2,9 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { USER_ACTIONS } from '../../redux/actions/userActions';
+import { connect } from 'react-redux'
 
+const mapStateToProps = state => ({ state });
 class RegisterPage extends Component {
   constructor(props) {
     super(props);
@@ -118,5 +120,5 @@ class RegisterPage extends Component {
   }
 }
 
-export default RegisterPage;
+export default connect(mapStateToProps)(RegisterPage);
 


### PR DESCRIPTION
This is something we will have to modify when we deploy it for them to temporarily allow them to have anyone be able to register (to register an admin) and then re-establish locking of registration to be allowed only by admins.